### PR TITLE
chore: update engine to version 3.1.21

### DIFF
--- a/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigrator.csproj
+++ b/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigrator.csproj
@@ -38,26 +38,26 @@
     <Reference Include="AeroWizard, Version=2.2.7.0, Culture=neutral, PublicKeyToken=915e74f5d64b8f37, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AeroWizard.2.2.7\lib\net45\AeroWizard.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataMigration.Core, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.DataMigration.Core.dll</HintPath>
+    <Reference Include="Capgemini.DataMigration.Core, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.DataMigration.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataMigration.Resiliency.Polly, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.DataMigration.Resiliency.Polly.dll</HintPath>
+    <Reference Include="Capgemini.DataMigration.Resiliency.Polly, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.DataMigration.Resiliency.Polly.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataScrambler, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.DataScrambler.dll</HintPath>
+    <Reference Include="Capgemini.DataScrambler, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.DataScrambler.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.Core, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.Core.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.Core, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.CrmStore, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.CrmStore.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.CrmStore, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.CrmStore.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.Engine, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.Engine.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.Engine, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.Engine.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.FileStore, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.FileStore.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.FileStore, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.FileStore.dll</HintPath>
     </Reference>
     <Reference Include="CsvHelper, Version=9.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CsvHelper.9.2.3\lib\net45\CsvHelper.dll</HintPath>

--- a/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigrator/packages.config
+++ b/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigrator/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AeroWizard" version="2.2.7" targetFramework="net462" />
-  <package id="Capgemini.Xrm.DataMigration.Engine" version="3.1.18" targetFramework="net462" />
+  <package id="Capgemini.Xrm.DataMigration.Engine" version="3.1.21" targetFramework="net462" />
   <package id="CsvHelper" version="9.2.3" targetFramework="net462" />
   <package id="DockPanelSuite" version="3.0.6" targetFramework="net462" />
   <package id="DockPanelSuite.ThemeVS2015" version="3.0.6" targetFramework="net462" />

--- a/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary.Tests.Unit/Capgemini.Xrm.CdsDataMigratorLibrary.Tests.Unit.csproj
+++ b/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary.Tests.Unit/Capgemini.Xrm.CdsDataMigratorLibrary.Tests.Unit.csproj
@@ -47,26 +47,26 @@
     <Reference Include="AeroWizard, Version=2.2.7.0, Culture=neutral, PublicKeyToken=915e74f5d64b8f37, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AeroWizard.2.2.7\lib\net45\AeroWizard.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataMigration.Core, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.DataMigration.Core.dll</HintPath>
+    <Reference Include="Capgemini.DataMigration.Core, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.DataMigration.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataMigration.Resiliency.Polly, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.DataMigration.Resiliency.Polly.dll</HintPath>
+    <Reference Include="Capgemini.DataMigration.Resiliency.Polly, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.DataMigration.Resiliency.Polly.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataScrambler, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.DataScrambler.dll</HintPath>
+    <Reference Include="Capgemini.DataScrambler, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.DataScrambler.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.Core, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.Core.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.Core, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.CrmStore, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.CrmStore.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.CrmStore, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.CrmStore.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.Engine, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.Engine.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.Engine, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.Engine.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.FileStore, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.FileStore.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.FileStore, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.FileStore.dll</HintPath>
     </Reference>
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.4.0\lib\net45\Castle.Core.dll</HintPath>
@@ -125,6 +125,9 @@
     </Reference>
     <Reference Include="Moq, Version=4.10.0.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.10.0\lib\net45\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>

--- a/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary.Tests.Unit/Services/CrmGenericMigratorFactoryTests.cs
+++ b/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary.Tests.Unit/Services/CrmGenericMigratorFactoryTests.cs
@@ -37,7 +37,8 @@ namespace Capgemini.Xrm.CdsDataMigrator.Tests.Unit.Services
         public void RequestJsonMigrator()
         {
             var logger = new Mock<ILogger>().Object;
-            var entityRepo = new Mock<IEntityRepository>().Object;
+            var entityRepoMock = new Mock<IEntityRepository>();
+            entityRepoMock.SetupGet(x => x.GetEntityMetadataCache).Returns(new Mock<IEntityMetadataCache>().Object);
             var exportConfig = new CrmExporterConfig
             {
                 JsonFolderPath = Path.Combine(Environment.CurrentDirectory, "temp")
@@ -45,7 +46,7 @@ namespace Capgemini.Xrm.CdsDataMigrator.Tests.Unit.Services
             var cancellationToken = CancellationToken.None;
             var schema = new CrmSchemaConfiguration();
 
-            var migrator = systemUnderTest.GetCrmDataMigrator(DataFormat.Json, logger, entityRepo, exportConfig, cancellationToken, schema);
+            var migrator = systemUnderTest.GetCrmDataMigrator(DataFormat.Json, logger, entityRepoMock.Object, exportConfig, cancellationToken, schema);
 
             migrator.Should().BeOfType<CrmFileDataExporter>();
         }
@@ -54,7 +55,8 @@ namespace Capgemini.Xrm.CdsDataMigrator.Tests.Unit.Services
         public void RequestCSVMigrator()
         {
             var logger = new Mock<ILogger>().Object;
-            var entityRepo = new Mock<IEntityRepository>().Object;
+            var entityRepoMock = new Mock<IEntityRepository>();
+            entityRepoMock.SetupGet(x => x.GetEntityMetadataCache).Returns(new Mock<IEntityMetadataCache>().Object);
             var exportConfig = new CrmExporterConfig
             {
                 JsonFolderPath = Path.Combine(Environment.CurrentDirectory, "temp")
@@ -63,7 +65,7 @@ namespace Capgemini.Xrm.CdsDataMigrator.Tests.Unit.Services
             var schema = new CrmSchemaConfiguration();
             schema.Entities.AddRange(new DataMigration.Model.CrmEntity[] { new DataMigration.Model.CrmEntity { } });
 
-            var migrator = systemUnderTest.GetCrmDataMigrator(DataFormat.Csv, logger, entityRepo, exportConfig, cancellationToken, schema);
+            var migrator = systemUnderTest.GetCrmDataMigrator(DataFormat.Csv, logger, entityRepoMock.Object, exportConfig, cancellationToken, schema);
 
             migrator.Should().BeOfType<CrmFileDataExporterCsv>();
         }

--- a/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary.Tests.Unit/app.config
+++ b/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary.Tests.Unit/app.config
@@ -54,6 +54,10 @@
         <assemblyIdentity name="McTools.Xrm.Connection" publicKeyToken="96037217801d9658" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-1.2021.1.39" newVersion="1.2021.1.39" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary.Tests.Unit/packages.config
+++ b/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary.Tests.Unit/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AeroWizard" version="2.2.7" targetFramework="net462" />
-  <package id="Capgemini.Xrm.DataMigration.Engine" version="3.1.18" targetFramework="net462" />
+  <package id="Capgemini.Xrm.DataMigration.Engine" version="3.1.21" targetFramework="net462" />
   <package id="Castle.Core" version="4.4.0" targetFramework="net462" />
   <package id="CsvHelper" version="9.2.3" targetFramework="net462" />
   <package id="DockPanelSuite" version="3.0.6" targetFramework="net462" />
@@ -21,6 +21,7 @@
   <package id="MscrmTools.Xrm.Connection" version="1.2020.12.37" targetFramework="net462" />
   <package id="MSTest.TestAdapter" version="2.2.3" targetFramework="net462" />
   <package id="MSTest.TestFramework" version="2.2.3" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net462" />
   <package id="Polly" version="5.9.0" targetFramework="net462" />
   <package id="SecurityCodeScan.VS2019" version="5.1.0" targetFramework="net462" developmentDependency="true" />

--- a/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary/Capgemini.Xrm.CdsDataMigratorLibrary.csproj
+++ b/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary/Capgemini.Xrm.CdsDataMigratorLibrary.csproj
@@ -34,26 +34,26 @@
     <Reference Include="AeroWizard, Version=2.2.7.0, Culture=neutral, PublicKeyToken=915e74f5d64b8f37, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AeroWizard.2.2.7\lib\net45\AeroWizard.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataMigration.Core, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.DataMigration.Core.dll</HintPath>
+    <Reference Include="Capgemini.DataMigration.Core, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.DataMigration.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataMigration.Resiliency.Polly, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.DataMigration.Resiliency.Polly.dll</HintPath>
+    <Reference Include="Capgemini.DataMigration.Resiliency.Polly, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.DataMigration.Resiliency.Polly.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.DataScrambler, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.DataScrambler.dll</HintPath>
+    <Reference Include="Capgemini.DataScrambler, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.DataScrambler.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.Core, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.Core.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.Core, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.CrmStore, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.CrmStore.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.CrmStore, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.CrmStore.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.Engine, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.Engine.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.Engine, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.Engine.dll</HintPath>
     </Reference>
-    <Reference Include="Capgemini.Xrm.DataMigration.FileStore, Version=3.1.18.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.18\lib\net462\Capgemini.Xrm.DataMigration.FileStore.dll</HintPath>
+    <Reference Include="Capgemini.Xrm.DataMigration.FileStore, Version=3.1.21.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Capgemini.Xrm.DataMigration.Engine.3.1.21\lib\net462\Capgemini.Xrm.DataMigration.FileStore.dll</HintPath>
     </Reference>
     <Reference Include="CsvHelper, Version=9.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
       <HintPath>..\..\packages\CsvHelper.9.2.3\lib\net45\CsvHelper.dll</HintPath>
@@ -99,6 +99,9 @@
     </Reference>
     <Reference Include="Microsoft.Xrm.Tooling.WebResourceUtility, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CrmSdk.XrmTooling.WpfControls.9.1.0.68\lib\net462\Microsoft.Xrm.Tooling.WebResourceUtility.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>

--- a/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary/app.config
+++ b/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary/app.config
@@ -14,6 +14,10 @@
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.3" newVersion="4.1.1.3" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary/packages.config
+++ b/Capgemini.Xrm.CdsDataMigrator/Capgemini.Xrm.CdsDataMigratorLibrary/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="AeroWizard" version="2.2.7" targetFramework="net462" />
-  <package id="Capgemini.Xrm.DataMigration.Engine" version="3.1.18" targetFramework="net462" />
+  <package id="Capgemini.Xrm.DataMigration.Engine" version="3.1.21" targetFramework="net462" />
   <package id="CsvHelper" version="9.2.3" targetFramework="net462" />
   <package id="DockPanelSuite" version="3.0.6" targetFramework="net462" />
   <package id="DockPanelSuite.ThemeVS2015" version="3.0.6" targetFramework="net462" />
@@ -16,6 +16,7 @@
   <package id="Microsoft.Rest.ClientRuntime" version="2.3.20" targetFramework="net462" />
   <package id="Microsoft.Web.Xdt" version="3.0.0" targetFramework="net462" />
   <package id="MscrmTools.Xrm.Connection" version="1.2020.12.37" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net462" />
   <package id="Polly" version="5.9.0" targetFramework="net462" />
   <package id="SecurityCodeScan.VS2019" version="5.1.0" targetFramework="net462" developmentDependency="true" />


### PR DESCRIPTION
fix: check the statecode field exists before applying the only active records filter